### PR TITLE
Do not use createImageBitmap for cropping on Safari.

### DIFF
--- a/src/loaders/HtmlImage.js
+++ b/src/loaders/HtmlImage.js
@@ -25,7 +25,7 @@ var once = require('../util/once');
 
 // Whether to use createImageBitmap instead of a canvas for cropping.
 // See https://caniuse.com/?search=createimagebitmap
-var useCreateImageBitmap = !!global.createImageBitmap && !browser.firefox;
+var useCreateImageBitmap = !!global.createImageBitmap && !browser.firefox && !browser.safari;
 
 // Options for createImageBitmap.
 var createImageBitmapOpts = {


### PR DESCRIPTION
It doesn't appear to work properly.

Fixes #417.